### PR TITLE
Add random mask generation for ControlNet

### DIFF
--- a/cell_train.py
+++ b/cell_train.py
@@ -22,6 +22,7 @@ from guided_diffusion.resample import create_named_schedule_sampler
 from guided_diffusion.script_util import (
     model_and_diffusion_defaults,
     create_model_and_diffusion,
+    create_controlled_model_and_diffusion,
     args_to_dict,
     add_dict_to_argparser,
 )
@@ -34,9 +35,14 @@ def main():
     seed_everything(1234)
     args = create_argparser().parse_args()
 
-    model, diffusion = create_model_and_diffusion(
-        **args_to_dict(args, model_and_diffusion_defaults().keys())
-    )
+    if args.use_controlnet:
+        model, diffusion = create_controlled_model_and_diffusion(
+            **args_to_dict(args, model_and_diffusion_defaults().keys())
+        )
+    else:
+        model, diffusion = create_model_and_diffusion(
+            **args_to_dict(args, model_and_diffusion_defaults().keys())
+        )
     schedule_sampler = create_named_schedule_sampler(args.schedule_sampler, diffusion)
 
     lit_model = DiffusionLitModule(
@@ -53,6 +59,8 @@ def main():
         batch_size=args.batch_size,
         vae_path=args.vae_path,
         train_vae=False,
+        use_controlnet=args.use_controlnet,
+        keep_ratio=args.keep_ratio,
     )
 
     period_checkpoint = ModelCheckpoint(
@@ -108,6 +116,8 @@ def create_argparser():
         use_fp16=False,
         fp16_scale_growth=1e-3,
         vae_path="output/Autoencoder_checkpoint/muris_AE/model_seed=0_step=0.pt",
+        use_controlnet=False,
+        keep_ratio=0.5,
         model_name="muris_diffusion",
         save_dir="output/diffusion_checkpoint",
     )

--- a/guided_diffusion/cell_datasets_loader.py
+++ b/guided_diffusion/cell_datasets_loader.py
@@ -107,11 +107,15 @@ class CellDataset(Dataset):
     def __init__(
         self,
         cell_data,
-        class_name
+        class_name,
+        use_controlnet=False,
+        keep_ratio=0.5,
     ):
         super().__init__()
         self.data = cell_data
         self.class_name = class_name
+        self.use_controlnet = use_controlnet
+        self.keep_ratio = keep_ratio
 
     def __len__(self):
         return self.data.shape[0]
@@ -121,5 +125,13 @@ class CellDataset(Dataset):
         out_dict = {}
         if self.class_name is not None:
             out_dict["y"] = np.array(self.class_name[idx], dtype=np.int64)
+        if self.use_controlnet:
+            control = np.full_like(arr, -1.0, dtype=np.float32)
+            nz = np.where(arr != 0)[0]
+            if len(nz) > 0:
+                mask = np.random.rand(len(nz)) < self.keep_ratio
+                keep_idx = nz[mask]
+                control[keep_idx] = arr[keep_idx]
+            out_dict["control"] = control
         return arr, out_dict
 

--- a/guided_diffusion/controlnet.py
+++ b/guided_diffusion/controlnet.py
@@ -1,0 +1,31 @@
+import torch
+import torch.nn as nn
+
+from .cell_model import Cell_Unet
+from .nn import zero_module
+
+
+class ControlNet(nn.Module):
+    """Apply external control to the diffusion model."""
+
+    def __init__(self, input_dim=2, hidden_num=None, dropout=0.1):
+        super().__init__()
+        if hidden_num is None:
+            hidden_num = [2000, 1000, 500, 500]
+        self.control_unet = Cell_Unet(input_dim, hidden_num, dropout)
+        # Start from zero weights so control net does not affect inference if not trained
+        zero_module(self.control_unet)
+
+    @staticmethod
+    def preprocess_control(x):
+        """Convert raw control matrix to network input and mask."""
+        mask = x.ne(-1).float()
+        x = x.clone()
+        x[x == -1] = 0
+        x = torch.log1p(x)
+        return x, mask
+
+    def forward(self, control, t):
+        control, mask = self.preprocess_control(control)
+        out = self.control_unet(control, t)
+        return out * mask

--- a/guided_diffusion/script_util.py
+++ b/guided_diffusion/script_util.py
@@ -3,7 +3,7 @@ import inspect
 
 from . import gaussian_diffusion as gd
 from .respace import SpacedDiffusion, space_timesteps
-from .cell_model import Cell_classifier, Cell_Unet
+from .cell_model import Cell_classifier, Cell_Unet, ControlledCellUnet
 
 NUM_CLASSES = 11
 
@@ -93,6 +93,46 @@ def create_model(
         hidden_dim,
         dropout=dropout
     )
+
+
+
+def create_controlled_model(
+    input_dim,
+    hidden_dim,
+    dropout,
+):
+    return ControlledCellUnet(input_dim, hidden_dim, dropout)
+
+def create_controlled_model_and_diffusion(
+    input_dim,
+    hidden_dim,
+    class_cond,
+    learn_sigma,
+    diffusion_steps,
+    noise_schedule,
+    timestep_respacing,
+    use_kl,
+    predict_xstart,
+    rescale_timesteps,
+    rescale_learned_sigmas,
+    dropout,
+):
+    model = create_controlled_model(
+        input_dim,
+        hidden_dim,
+        dropout
+    )
+    diffusion = create_gaussian_diffusion(
+        steps=diffusion_steps,
+        learn_sigma=learn_sigma,
+        noise_schedule=noise_schedule,
+        use_kl=use_kl,
+        predict_xstart=predict_xstart,
+        rescale_timesteps=rescale_timesteps,
+        rescale_learned_sigmas=rescale_learned_sigmas,
+        timestep_respacing=timestep_respacing,
+    )
+    return model, diffusion
 
 
 def create_classifier_and_diffusion(


### PR DESCRIPTION
## Summary
- generate ControlNet inputs on the fly by masking nonzero elements
- add `keep_ratio` option in Lightning DataModule and CLI
- revise ControlNet preprocessing to treat -1 as mask value

## Testing
- `python -m py_compile guided_diffusion/*.py cell_train.py`

------
https://chatgpt.com/codex/tasks/task_e_685b5c0718e8832a96eb851de529b958