### PR TITLE
Initialize BERT models in Lightning module

### DIFF
--- a/cell_train.py
+++ b/cell_train.py
@@ -52,6 +52,9 @@ def main():
         weight_decay=args.weight_decay,
         schedule_sampler=schedule_sampler,
         lr_anneal_steps=args.lr_anneal_steps,
+        vae_path=args.vae_path,
+        train_vae=False,
+        hidden_dim=128,
     )
 
     data_module = CellDataModule(

--- a/guided_diffusion/controlnet.py
+++ b/guided_diffusion/controlnet.py
@@ -12,7 +12,7 @@ class ControlNet(nn.Module):
         super().__init__()
         if hidden_num is None:
             hidden_num = [2000, 1000, 500, 500]
-        self.control_unet = Cell_Unet(input_dim, hidden_num, dropout)
+        self.control_unet = Cell_Unet(input_dim, hidden_num, dropout, cond_dim=0)
         # Start from zero weights so control net does not affect inference if not trained
         zero_module(self.control_unet)
 

--- a/guided_diffusion/lightning_module.py
+++ b/guided_diffusion/lightning_module.py
@@ -1,6 +1,12 @@
 import pytorch_lightning as pl
 import torch as th
 from torch.optim import AdamW
+from transformers import AutoTokenizer, AutoModel
+
+from .cell_datasets_loader import load_VAE
+
+PUBMED_MODEL_NAME = "microsoft/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext"
+CHEMBERT_MODEL_NAME = "ChemBERTa-2"
 
 from .resample import LossAwareSampler, UniformSampler
 
@@ -8,8 +14,18 @@ from .resample import LossAwareSampler, UniformSampler
 class DiffusionLitModule(pl.LightningModule):
     """LightningModule for training diffusion models."""
 
-    def __init__(self, model, diffusion, lr=1e-4, weight_decay=0.0,
-                 schedule_sampler=None, lr_anneal_steps=0):
+    def __init__(
+        self,
+        model,
+        diffusion,
+        lr=1e-4,
+        weight_decay=0.0,
+        schedule_sampler=None,
+        lr_anneal_steps=0,
+        vae_path=None,
+        train_vae=False,
+        hidden_dim=128,
+    ):
         super().__init__()
         self.model = model
         self.diffusion = diffusion
@@ -19,16 +35,91 @@ class DiffusionLitModule(pl.LightningModule):
         self.weight_decay = weight_decay
         self.schedule_sampler = schedule_sampler or UniformSampler(diffusion)
         self.lr_anneal_steps = lr_anneal_steps
+        self.vae_path = vae_path
+        self.train_vae = train_vae
+        self.hidden_dim = hidden_dim
+        self.autoencoder = None
+
+        # Preload tokenizers and encoders for conditional embeddings
+        self.pubmed_tokenizer = AutoTokenizer.from_pretrained(PUBMED_MODEL_NAME)
+        self.pubmed_encoder = AutoModel.from_pretrained(PUBMED_MODEL_NAME)
+        self.chem_tokenizer = AutoTokenizer.from_pretrained(CHEMBERT_MODEL_NAME)
+        self.chem_token_encoder = AutoModel.from_pretrained(CHEMBERT_MODEL_NAME)
+        self.pubmed_encoder.eval()
+        self.chem_token_encoder.eval()
+        for p in self.pubmed_encoder.parameters():
+            p.requires_grad_(False)
+        for p in self.chem_token_encoder.parameters():
+            p.requires_grad_(False)
+
+        # mapper for combined PubMed and Chem embeddings
+        self.cond_mapper = th.nn.Linear(1536, 768)
+        # initialize to average the two halves
+        with th.no_grad():
+            w = th.zeros(768, 1536)
+            eye = th.eye(768)
+            w[:, :768] = 0.5 * eye
+            w[:, 768:] = 0.5 * eye
+            self.cond_mapper.weight.copy_(w)
+            self.cond_mapper.bias.zero_()
+
+        # mapper for standalone Chem embeddings
+        self.chem_mapper = th.nn.Linear(768, 768)
+        with th.no_grad():
+            self.chem_mapper.weight.copy_(th.eye(768))
+            self.chem_mapper.bias.zero_()
+
+    def configure_model(self):
+        if not self.train_vae and self.autoencoder is None:
+            dm = self.trainer.datamodule
+            num_gene = dm.dataset.data.shape[1]
+            self.autoencoder = load_VAE(self.vae_path, num_gene, self.hidden_dim)
+            self.autoencoder.eval()
+            for p in self.autoencoder.parameters():
+                p.requires_grad_(False)
 
     def training_step(self, batch, batch_idx):
         x, cond = batch
+        if not self.train_vae:
+            with th.no_grad():
+                x = self.autoencoder(x, return_latent=True)
+        prompts = cond.pop("prompt", None)
+        smiles = cond.pop("smiles", None)
+        cond_emb = None
+        if prompts is not None:
+            with th.no_grad():
+                tok = self.pubmed_tokenizer(list(prompts), padding=True, truncation=True, return_tensors="pt")
+                tok = {k: v.to(self.device) for k, v in tok.items()}
+                emb_pub = self.pubmed_encoder(**tok).last_hidden_state[:, 0]
+        else:
+            emb_pub = None
+
+        if smiles is not None:
+            with th.no_grad():
+                tok = self.chem_tokenizer(list(smiles), padding=True, truncation=True, return_tensors="pt")
+                tok = {k: v.to(self.device) for k, v in tok.items()}
+                emb_chem = self.chem_token_encoder(**tok).last_hidden_state[:, 0]
+        else:
+            emb_chem = None
+
+        if emb_pub is not None and emb_chem is not None:
+            cond_emb = self.cond_mapper(th.cat([emb_pub, emb_chem], dim=1))
+        elif emb_pub is not None:
+            cond_emb = emb_pub
+        elif emb_chem is not None:
+            cond_emb = self.chem_mapper(emb_chem)
+
+        if cond_emb is not None:
+            cond["cond_emb"] = cond_emb
+
         t, weights = self.schedule_sampler.sample(x.shape[0], x.device)
         losses = self.diffusion.training_losses(self.model, x, t, model_kwargs=cond)
 
         if isinstance(self.schedule_sampler, LossAwareSampler):
             self.schedule_sampler.update_with_local_losses(t, losses["loss"].detach())
 
-        ts = t.cpu().numpy()
+        # map timesteps to quartile ids without leaving the device
+        quartiles = (t * 4 // self.diffusion.num_timesteps).long()
         # weight each loss term the same way as the original TrainLoop
         for key, val in losses.items():
             weighted = val * weights
@@ -36,11 +127,15 @@ class DiffusionLitModule(pl.LightningModule):
             self.log(key, mean_val, prog_bar=key in ["loss", "mse"], on_step=True, on_epoch=False)
 
             # Log quartile statistics to match the original logger behaviour
-            vals_np = weighted.detach().cpu().numpy()
             for q in range(4):
-                mask = [i for i, qt in enumerate(ts) if int(4 * qt / self.diffusion.num_timesteps) == q]
-                if mask:
-                    self.log(f"{key}_q{q}", float(vals_np[mask].mean()), on_step=True, on_epoch=False)
+                mask = quartiles == q
+                if mask.any():
+                    self.log(
+                        f"{key}_q{q}",
+                        weighted[mask].mean().item(),
+                        on_step=True,
+                        on_epoch=False,
+                    )
 
         return (losses["loss"] * weights).mean()
 

--- a/guided_diffusion/script_util.py
+++ b/guided_diffusion/script_util.py
@@ -32,7 +32,8 @@ def model_and_diffusion_defaults():
     res = dict(
         input_dim = 128,
         hidden_dim = [512,512,256,128],
-        dropout = 0.0
+        dropout = 0.0,
+        cond_dim = 768
     )
     res.update(diffusion_defaults())
     return res
@@ -63,11 +64,13 @@ def create_model_and_diffusion(
     rescale_timesteps,
     rescale_learned_sigmas,
     dropout,
+    cond_dim,
 ):
     model = create_model(
         input_dim,
         hidden_dim,
-        dropout=dropout
+        dropout=dropout,
+        cond_dim=cond_dim,
     )
     diffusion = create_gaussian_diffusion(
         steps=diffusion_steps,
@@ -86,12 +89,14 @@ def create_model(
     input_dim,
     hidden_dim,
     dropout,
+    cond_dim=0,
 ):
 
     return Cell_Unet(
         input_dim,
         hidden_dim,
-        dropout=dropout
+        dropout=dropout,
+        cond_dim=cond_dim
     )
 
 
@@ -100,8 +105,9 @@ def create_controlled_model(
     input_dim,
     hidden_dim,
     dropout,
+    cond_dim=0,
 ):
-    return ControlledCellUnet(input_dim, hidden_dim, dropout)
+    return ControlledCellUnet(input_dim, hidden_dim, dropout, cond_dim)
 
 def create_controlled_model_and_diffusion(
     input_dim,
@@ -116,11 +122,13 @@ def create_controlled_model_and_diffusion(
     rescale_timesteps,
     rescale_learned_sigmas,
     dropout,
+    cond_dim,
 ):
     model = create_controlled_model(
         input_dim,
         hidden_dim,
-        dropout
+        dropout,
+        cond_dim,
     )
     diffusion = create_gaussian_diffusion(
         steps=diffusion_steps,


### PR DESCRIPTION
## Summary
- dataset loader prepares prompts and SMILES without applying the VAE
- Lightning module loads the VAE during configure_model and encodes inputs on the fly
- training script passes the VAE path to the module
- switch from `setup` to `configure_model` to align with Lightning's API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cf5840554832a816c4428227d5de8