### PR TITLE
Initialize BERT models in Lightning module

### DIFF
--- a/cell_train.py
+++ b/cell_train.py
@@ -52,13 +52,14 @@ def main():
         weight_decay=args.weight_decay,
         schedule_sampler=schedule_sampler,
         lr_anneal_steps=args.lr_anneal_steps,
+        vae_path=args.vae_path,
+        train_vae=False,
+        hidden_dim=128,
     )
 
     data_module = CellDataModule(
-        data_dir=args.data_dir,
+        spec_path=args.data_jsonl,
         batch_size=args.batch_size,
-        vae_path=args.vae_path,
-        train_vae=False,
         use_controlnet=args.use_controlnet,
         keep_ratio=args.keep_ratio,
     )
@@ -102,7 +103,7 @@ def main():
 
 def create_argparser():
     defaults = dict(
-        data_dir="/data1/lep/Workspace/guided-diffusion/data/tabula_muris/all.h5ad",
+        data_jsonl="/path/to/spec.jsonl",
         schedule_sampler="uniform",
         lr=1e-4,
         weight_decay=0.0001,

--- a/guided_diffusion/cell_datasets_loader.py
+++ b/guided_diffusion/cell_datasets_loader.py
@@ -5,6 +5,10 @@ from PIL import Image
 import blobfile as bf
 import numpy as np
 from torch.utils.data import DataLoader, Dataset
+import pandas as pd
+import glob
+import os
+from functools import lru_cache
 
 import scanpy as sc
 import torch
@@ -12,6 +16,26 @@ import sys
 sys.path.append('..')
 from VAE.VAE_model import VAE
 from sklearn.preprocessing import LabelEncoder
+
+
+PROMPT_TEMPLATE = (
+    "In this cell-based experiment, {cell_name} cells (cell line {cell_line_id}) "
+    "were treated with {drug} at {drug_concentration_with_unit} "
+    "[PubChem CID {pubchem_cid}; SMILES {canonical_smiles}]. "
+    "The broad mechanism of action was {moa_broad} and the fine mechanism was {moa_fine}; "
+    "reported targets: {targets}. "
+    "Following treatment, cells showed gene count {gene_count}, "
+    "transcript count {tscp_count}, mitochondrial read count {mread_count}, "
+    "mitochondrial fraction {pcnt_mito:.4f}, S-phase score {S_score:.4f}, "
+    "G2M-phase score {G2M_score:.4f}, and were assigned to the {phase} phase. "
+    "The drug {approved_str} and {trials_str}. "
+    "Additional notes: {gpt_notes_approval}"
+)
+
+@lru_cache(maxsize=8)
+def read_h5ad_backed(path: str):
+    """Load an AnnData object in backed read-only mode with caching."""
+    return sc.read_h5ad(path, backed="r")
 
 def stabilize(expression_matrix):
     ''' Use Anscombes approximation to variance stabilize Negative Binomial data
@@ -58,7 +82,22 @@ def load_data(
     if not data_dir:
         raise ValueError("unspecified data directory")
 
-    adata = sc.read_h5ad(data_dir)
+    if os.path.isdir(data_dir):
+        h5ad_files = glob.glob(os.path.join(data_dir, "*.h5ad"))
+        if not h5ad_files:
+            raise ValueError(f"no h5ad files found in {data_dir}")
+        adatas = [sc.read_h5ad(f) for f in h5ad_files]
+        adata = sc.concat(
+            adatas,
+            axis=0,
+            join="outer",
+            label="batch",
+            keys=[os.path.basename(f)[:-5] for f in h5ad_files],
+            fill_value=0,
+            index_unique="-",
+        )
+    else:
+        adata = sc.read_h5ad(data_dir)
     
     # preporcess the data. modify this part if use your own dataset. the gene expression must first norm1e4 then log1p
     sc.pp.filter_genes(adata, min_cells=3)
@@ -80,16 +119,52 @@ def load_data(
 
     cell_data = adata.X.toarray()
 
+    # Prepare prompts and SMILES strings for later conditioning
+    prompts = []
+    smiles = []
+    for _, row in adata.obs.iterrows():
+        canonical = row.get("canonical_smiles")
+        if canonical is not None and not pd.isna(canonical):
+            smiles.append(canonical)
+            canonical_prompt = canonical
+        else:
+            smiles.append(None)
+            canonical_prompt = "None"
+        prompt = PROMPT_TEMPLATE.format(
+            cell_name=row["cell_name"],
+            cell_line_id=row["cell_line_id"],
+            drug=row["drug"],
+            drug_concentration_with_unit=row["drug_concentration_with_unit"].replace(" ", ""),
+            pubchem_cid=row["pubchem_cid"],
+            canonical_smiles=canonical_prompt,
+            moa_broad=row["moa-broad"],
+            moa_fine=row["moa-fine"],
+            targets=row.get("targets", "unknown"),
+            gene_count=row["gene_count"],
+            tscp_count=row["tscp_count"],
+            mread_count=row["mread_count"],
+            pcnt_mito=row["pcnt_mito"],
+            S_score=row["S_score"],
+            G2M_score=row["G2M_score"],
+            phase=row["phase"],
+            approved_str="is human-approved" if row["human-approved"] == "yes" else "is not human-approved",
+            trials_str="is in clinical trials" if row["clinical-trials"] == "yes" else "is not in clinical trials",
+            gpt_notes_approval=row["gpt-notes-approval"],
+        )
+        prompts.append(prompt)
+
     # turn the gene expression into latent space. use this if training the diffusion backbone.
     if not train_vae:
         num_gene = cell_data.shape[1]
-        autoencoder = load_VAE(vae_path,num_gene,hidden_dim)
-        cell_data = autoencoder(torch.tensor(cell_data).cuda(),return_latent=True)
+        autoencoder = load_VAE(vae_path, num_gene, hidden_dim)
+        cell_data = autoencoder(torch.tensor(cell_data).cuda(), return_latent=True)
         cell_data = cell_data.cpu().detach().numpy()
     
     dataset = CellDataset(
         cell_data,
-        classes
+        classes,
+        prompts,
+        smiles,
     )
     if deterministic:
         loader = DataLoader(
@@ -106,25 +181,89 @@ def load_data(
 class CellDataset(Dataset):
     def __init__(
         self,
-        cell_data,
-        class_name,
+        files,
+        lengths,
+        prompt_templates=None,
+        smiles_cols=None,
         use_controlnet=False,
         keep_ratio=0.5,
     ):
+        """Dataset that lazily reads rows from one or more H5AD files.
+
+        Parameters
+        ----------
+        files : list[str]
+            Paths to backed ``.h5ad`` files.
+        lengths : list[int]
+            Number of cells in each file.
+        prompt_templates : list[str] or None
+            Prompt format strings corresponding to ``files``. ``None`` disables
+            prompt generation for that file.
+        smiles_cols : list[str] or None
+            Column names for SMILES strings. ``None`` disables ChemBERT
+            conditioning for that file.
+        """
+
         super().__init__()
-        self.data = cell_data
-        self.class_name = class_name
+        self.files = files
+        self.lengths = lengths
+        self.cumsum = np.cumsum(lengths)
+        self.total_len = int(self.cumsum[-1])
+        if prompt_templates is None:
+            prompt_templates = [None] * len(files)
+        if smiles_cols is None:
+            smiles_cols = [None] * len(files)
+        assert len(prompt_templates) == len(files)
+        assert len(smiles_cols) == len(files)
+        self.prompt_templates = list(prompt_templates)
+        self.smiles_cols = list(smiles_cols)
         self.use_controlnet = use_controlnet
         self.keep_ratio = keep_ratio
 
     def __len__(self):
-        return self.data.shape[0]
+        return self.total_len
+
+    def _locate(self, idx):
+        file_idx = int(np.searchsorted(self.cumsum, idx, side="right"))
+        if file_idx == 0:
+            local_idx = idx
+        else:
+            local_idx = idx - int(self.cumsum[file_idx - 1])
+        return file_idx, self.files[file_idx], local_idx
 
     def __getitem__(self, idx):
-        arr = self.data[idx]
+        file_idx, path, local_idx = self._locate(idx)
+        adata = read_h5ad_backed(path)
+        row = adata[local_idx]
+        arr = row.X
+        if hasattr(arr, "toarray"):
+            arr = arr.toarray().ravel().astype(np.float32)
+        else:
+            arr = np.array(arr, dtype=np.float32)
         out_dict = {}
-        if self.class_name is not None:
-            out_dict["y"] = np.array(self.class_name[idx], dtype=np.int64)
+
+        # smiles string
+        canonical = None
+        col = self.smiles_cols[file_idx]
+        if col and col in row.obs.columns:
+            canonical = row.obs[col].values[0]
+            if pd.isna(canonical):
+                canonical = None
+        out_dict["smiles"] = canonical
+
+        # prompt construction
+        template = self.prompt_templates[file_idx]
+        if template is not None:
+            row_dict = row.obs.iloc[0].to_dict()
+            canonical_prompt = canonical if canonical is not None else "None"
+            row_dict.setdefault("canonical_smiles", canonical_prompt)
+            if "drug_concentration_with_unit" in row_dict:
+                row_dict["drug_concentration_with_unit"] = str(row_dict["drug_concentration_with_unit"]).replace(" ", "")
+            prompt = template.format(**row_dict)
+        else:
+            prompt = None
+        out_dict["prompt"] = prompt
+
         if self.use_controlnet:
             control = np.full_like(arr, -1.0, dtype=np.float32)
             nz = np.where(arr != 0)[0]
@@ -133,5 +272,6 @@ class CellDataset(Dataset):
                 keep_idx = nz[mask]
                 control[keep_idx] = arr[keep_idx]
             out_dict["control"] = control
+
         return arr, out_dict
 

--- a/guided_diffusion/controlnet.py
+++ b/guided_diffusion/controlnet.py
@@ -12,7 +12,7 @@ class ControlNet(nn.Module):
         super().__init__()
         if hidden_num is None:
             hidden_num = [2000, 1000, 500, 500]
-        self.control_unet = Cell_Unet(input_dim, hidden_num, dropout)
+        self.control_unet = Cell_Unet(input_dim, hidden_num, dropout, cond_dim=0)
         # Start from zero weights so control net does not affect inference if not trained
         zero_module(self.control_unet)
 

--- a/guided_diffusion/lightning_module.py
+++ b/guided_diffusion/lightning_module.py
@@ -1,6 +1,12 @@
 import pytorch_lightning as pl
 import torch as th
 from torch.optim import AdamW
+from transformers import AutoTokenizer, AutoModel
+
+from .cell_datasets_loader import load_VAE, read_h5ad_backed
+
+PUBMED_MODEL_NAME = "microsoft/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext"
+CHEMBERT_MODEL_NAME = "ChemBERTa-2"
 
 from .resample import LossAwareSampler, UniformSampler
 
@@ -8,8 +14,18 @@ from .resample import LossAwareSampler, UniformSampler
 class DiffusionLitModule(pl.LightningModule):
     """LightningModule for training diffusion models."""
 
-    def __init__(self, model, diffusion, lr=1e-4, weight_decay=0.0,
-                 schedule_sampler=None, lr_anneal_steps=0):
+    def __init__(
+        self,
+        model,
+        diffusion,
+        lr=1e-4,
+        weight_decay=0.0,
+        schedule_sampler=None,
+        lr_anneal_steps=0,
+        vae_path=None,
+        train_vae=False,
+        hidden_dim=128,
+    ):
         super().__init__()
         self.model = model
         self.diffusion = diffusion
@@ -19,16 +35,127 @@ class DiffusionLitModule(pl.LightningModule):
         self.weight_decay = weight_decay
         self.schedule_sampler = schedule_sampler or UniformSampler(diffusion)
         self.lr_anneal_steps = lr_anneal_steps
+        self.vae_path = vae_path
+        self.train_vae = train_vae
+        self.hidden_dim = hidden_dim
+        self.autoencoder = None
+
+        # Preload tokenizers and encoders for conditional embeddings
+        self.pubmed_tokenizer = AutoTokenizer.from_pretrained(PUBMED_MODEL_NAME)
+        self.pubmed_encoder = AutoModel.from_pretrained(PUBMED_MODEL_NAME)
+        self.chem_tokenizer = AutoTokenizer.from_pretrained(CHEMBERT_MODEL_NAME)
+        self.chem_token_encoder = AutoModel.from_pretrained(CHEMBERT_MODEL_NAME)
+        self.pubmed_encoder.eval()
+        self.chem_token_encoder.eval()
+        for p in self.pubmed_encoder.parameters():
+            p.requires_grad_(False)
+        for p in self.chem_token_encoder.parameters():
+            p.requires_grad_(False)
+        self.embed_dim = self.pubmed_encoder.config.hidden_size
+
+        # mapper for combined PubMed and Chem embeddings
+        self.cond_mapper = th.nn.Linear(1536, 768)
+        # initialize to average the two halves
+        with th.no_grad():
+            w = th.zeros(768, 1536)
+            eye = th.eye(768)
+            w[:, :768] = 0.5 * eye
+            w[:, 768:] = 0.5 * eye
+            self.cond_mapper.weight.copy_(w)
+            self.cond_mapper.bias.zero_()
+
+        # mapper for standalone Chem embeddings
+        self.chem_mapper = th.nn.Linear(768, 768)
+        with th.no_grad():
+            self.chem_mapper.weight.copy_(th.eye(768))
+            self.chem_mapper.bias.zero_()
+
+    def configure_model(self, stage=None):
+        if not self.train_vae and self.autoencoder is None:
+            dm = self.trainer.datamodule
+            num_gene = getattr(dm, "gene_dim", None)
+            if num_gene is None:
+                ds = dm.dataset
+                path = ds.files[0]
+                num_gene = read_h5ad_backed(path).shape[1]
+            self.autoencoder = load_VAE(self.vae_path, num_gene, self.hidden_dim)
+            self.autoencoder.eval()
+            for p in self.autoencoder.parameters():
+                p.requires_grad_(False)
+
+    def on_fit_start(self):
+        self.configure_model()
 
     def training_step(self, batch, batch_idx):
         x, cond = batch
+        if not self.train_vae:
+            with th.no_grad():
+                x = self.autoencoder(x, return_latent=True)
+        prompts = cond.pop("prompt", None)
+        smiles = cond.pop("smiles", None)
+        cond_emb = None
+        emb_pub = None
+        batch_size = x.shape[0]
+        all_prompt_none = prompts is None or all(p is None for p in prompts)
+        all_smiles_none = smiles is None or all(s is None for s in smiles)
+        if prompts is not None:
+            valid_idx = [i for i, p in enumerate(prompts) if p is not None]
+            if valid_idx:
+                with th.no_grad():
+                    tok = self.pubmed_tokenizer(
+                        [prompts[i] for i in valid_idx],
+                        padding=True,
+                        truncation=True,
+                        return_tensors="pt",
+                    )
+                    tok = {k: v.to(self.device) for k, v in tok.items()}
+                    emb = self.pubmed_encoder(**tok).last_hidden_state[:, 0]
+                emb_pub = th.zeros(len(prompts), emb.shape[1], device=self.device)
+                emb_pub[valid_idx] = emb
+            else:
+                emb_pub = th.zeros(batch_size, self.embed_dim, device=self.device)
+        else:
+            emb_pub = th.zeros(batch_size, self.embed_dim, device=self.device)
+
+        emb_chem = None
+        if smiles is not None:
+            valid_idx = [i for i, s in enumerate(smiles) if s is not None]
+            if valid_idx:
+                with th.no_grad():
+                    tok = self.chem_tokenizer(
+                        [smiles[i] for i in valid_idx],
+                        padding=True,
+                        truncation=True,
+                        return_tensors="pt",
+                    )
+                    tok = {k: v.to(self.device) for k, v in tok.items()}
+                    emb = self.chem_token_encoder(**tok).last_hidden_state[:, 0]
+                emb_chem = th.zeros(len(smiles), emb.shape[1], device=self.device)
+                emb_chem[valid_idx] = emb
+            else:
+                emb_chem = th.zeros(batch_size, self.embed_dim, device=self.device)
+        else:
+            emb_chem = th.zeros(batch_size, self.embed_dim, device=self.device)
+
+        if not (all_prompt_none and all_smiles_none):
+            if emb_pub is not None and emb_chem is not None:
+                cond_emb = self.cond_mapper(th.cat([emb_pub, emb_chem], dim=1))
+            elif emb_pub is not None and not all_prompt_none:
+                cond_emb = emb_pub
+            elif emb_chem is not None and not all_smiles_none:
+                cond_emb = self.chem_mapper(emb_chem)
+
+        if cond_emb is not None:
+            cond["cond_emb"] = cond_emb
+
         t, weights = self.schedule_sampler.sample(x.shape[0], x.device)
         losses = self.diffusion.training_losses(self.model, x, t, model_kwargs=cond)
 
         if isinstance(self.schedule_sampler, LossAwareSampler):
             self.schedule_sampler.update_with_local_losses(t, losses["loss"].detach())
 
-        ts = t.cpu().numpy()
+        # map timesteps to quartile ids without leaving the device
+        quartiles = (t * 4 // self.diffusion.num_timesteps).long()
         # weight each loss term the same way as the original TrainLoop
         for key, val in losses.items():
             weighted = val * weights
@@ -36,11 +163,15 @@ class DiffusionLitModule(pl.LightningModule):
             self.log(key, mean_val, prog_bar=key in ["loss", "mse"], on_step=True, on_epoch=False)
 
             # Log quartile statistics to match the original logger behaviour
-            vals_np = weighted.detach().cpu().numpy()
             for q in range(4):
-                mask = [i for i, qt in enumerate(ts) if int(4 * qt / self.diffusion.num_timesteps) == q]
-                if mask:
-                    self.log(f"{key}_q{q}", float(vals_np[mask].mean()), on_step=True, on_epoch=False)
+                mask = quartiles == q
+                if mask.any():
+                    self.log(
+                        f"{key}_q{q}",
+                        weighted[mask].mean().item(),
+                        on_step=True,
+                        on_epoch=False,
+                    )
 
         return (losses["loss"] * weights).mean()
 

--- a/guided_diffusion/script_util.py
+++ b/guided_diffusion/script_util.py
@@ -32,7 +32,8 @@ def model_and_diffusion_defaults():
     res = dict(
         input_dim = 128,
         hidden_dim = [512,512,256,128],
-        dropout = 0.0
+        dropout = 0.0,
+        cond_dim = 768
     )
     res.update(diffusion_defaults())
     return res
@@ -63,11 +64,13 @@ def create_model_and_diffusion(
     rescale_timesteps,
     rescale_learned_sigmas,
     dropout,
+    cond_dim,
 ):
     model = create_model(
         input_dim,
         hidden_dim,
-        dropout=dropout
+        dropout=dropout,
+        cond_dim=cond_dim,
     )
     diffusion = create_gaussian_diffusion(
         steps=diffusion_steps,
@@ -86,12 +89,14 @@ def create_model(
     input_dim,
     hidden_dim,
     dropout,
+    cond_dim=0,
 ):
 
     return Cell_Unet(
         input_dim,
         hidden_dim,
-        dropout=dropout
+        dropout=dropout,
+        cond_dim=cond_dim
     )
 
 
@@ -100,8 +105,9 @@ def create_controlled_model(
     input_dim,
     hidden_dim,
     dropout,
+    cond_dim=0,
 ):
-    return ControlledCellUnet(input_dim, hidden_dim, dropout)
+    return ControlledCellUnet(input_dim, hidden_dim, dropout, cond_dim)
 
 def create_controlled_model_and_diffusion(
     input_dim,
@@ -116,11 +122,13 @@ def create_controlled_model_and_diffusion(
     rescale_timesteps,
     rescale_learned_sigmas,
     dropout,
+    cond_dim,
 ):
     model = create_controlled_model(
         input_dim,
         hidden_dim,
-        dropout
+        dropout,
+        cond_dim,
     )
     diffusion = create_gaussian_diffusion(
         steps=diffusion_steps,


### PR DESCRIPTION
## Summary
- handle multiple dataset specs in a single `CellDataset`
- `CellDataset` keeps per-file prompt templates and SMILES column names
- remove `ConcatDataset` handling in Lightning module
- return `None` placeholders for missing prompts/SMILES so dataloader works
- skip `None` prompts when generating PubMed embeddings
- treat missing prompt/SMILES as zero embeddings in the Lightning module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cf5840554832a816c4428227d5de8