### PR TITLE
Balanced file sampling per path

### DIFF
--- a/VAE/VAE_train.py
+++ b/VAE/VAE_train.py
@@ -1,148 +1,279 @@
 import argparse
 import os
-import time
 
-import numpy as np
 import torch
+import pytorch_lightning as pl
+from pytorch_lightning.callbacks import (
+    ModelCheckpoint,
+    LearningRateMonitor,
+    RichProgressBar,
+    RichModelSummary,
+)
+from functools import partial
+from pytorch_lightning.callbacks.progress.rich_progress import RichProgressBarTheme
+from pytorch_lightning import seed_everything
+from pytorch_lightning.loggers import TensorBoardLogger
+from pytorch_lightning.strategies import DDPStrategy, FSDPStrategy
+from torch.optim.lr_scheduler import (
+    LinearLR,
+    SequentialLR,
+    CosineAnnealingLR,
+)
+
+try:
+    from swanlab.integration.pytorch_lightning import SwanLabLogger
+except Exception:  # pragma: no cover - optional dependency
+    SwanLabLogger = None
+
 from VAE_model import VAE
-import sys
-sys.path.append("..")
-# from guided_diffusion.cell_datasets import load_data
-# from guided_diffusion.cell_datasets_sapiens import load_data
-# from guided_diffusion.cell_datasets_WOT import load_data
-# from guided_diffusion.cell_datasets_muris import load_data
-from guided_diffusion.cell_datasets_loader import load_data
-
-torch.autograd.set_detect_anomaly(True)
-import random
-
-def seed_everything(seed):
-    random.seed(seed)
-    np.random.seed(seed)
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
-    torch.backends.cudnn.deterministic = True
+from guided_diffusion.console_logger import ConsoleLogger
+from guided_diffusion.lightning_data import CellDataModule
 
 
-def prepare_vae(args, state_dict=None):
-    """
-    Instantiates autoencoder and dataset to run an experiment.
-    """
-
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-
-    datasets = load_data(
-        data_dir=args["data_dir"],
-        batch_size=args["batch_size"],
-        train_vae=True,
-    )
-
-    autoencoder = VAE(
-        num_genes=args["num_genes"],
-        device=device,
-        seed=args["seed"],
-        loss_ae=args["loss_ae"],
-        hidden_dim=128,
-        decoder_activation=args["decoder_activation"],
-    )
-    if state_dict is not None:
-        print('loading pretrained model from: \n',state_dict)
-        use_gpu = device == "cuda"
-        autoencoder.encoder.load_state(state_dict["encoder"], use_gpu)
-        autoencoder.decoder.load_state(state_dict["decoder"], use_gpu)
-
-    return autoencoder, datasets
-
-
-def train_vae(args, return_model=False):
-    """
-    Trains a autoencoder
-    """
-    if args["state_dict"] is not None:
-        filenames = {}
-        checkpoint_path = {
-            "encoder": os.path.join(
-                args["state_dict"], filenames.get("model", "encoder.ckpt")
-            ),
-            "decoder": os.path.join(
-                args["state_dict"], filenames.get("model", "decoder.ckpt")
-            ),
-            "gene_order": os.path.join(
-                args["state_dict"], filenames.get("gene_order", "gene_order.tsv")
-            ),
-        }
-        autoencoder, datasets = prepare_vae(args, checkpoint_path)
-    else:
-        autoencoder, datasets = prepare_vae(args)
-   
-    args["hparams"] = autoencoder.hparams
-
-    start_time = time.time()
-    for step in range(args["max_steps"]):
-
-        genes, _ = next(datasets)
-
-        minibatch_training_stats = autoencoder.train_step(genes)
-
-        if step % 1000 == 0:
-            for key, val in minibatch_training_stats.items():
-                print('step ', step, 'loss ', val)
-
-        ellapsed_minutes = (time.time() - start_time) / 60
-
-        stop = ellapsed_minutes > args["max_minutes"] or (
-            step == args["max_steps"] - 1
-        )
-
-        if ((step % args["checkpoint_freq"]) == 0 or stop):
-
-            os.makedirs(args["save_dir"],exist_ok=True)
-            torch.save(
-                autoencoder.state_dict(),
-                os.path.join(
-                    args["save_dir"],
-                    "model_seed={}_step={}.pt".format(args["seed"], step),
-                ),
-            )
-
-            if stop:
-                break
-
-    if return_model:
-        return autoencoder, datasets
+torch.set_float32_matmul_precision("medium")
 
 
 def parse_arguments():
-    """
-    Read arguments if this script is called from a terminal.
-    """
-
     parser = argparse.ArgumentParser(description="Finetune Scimilarity")
-    # dataset arguments
-    parser.add_argument("--data_dir", type=str, default='/data1/lep/Workspace/guided-diffusion/data/tabula_muris/all.h5ad')
+    parser.add_argument(
+        "--data_jsonl",
+        type=str,
+        default="/data1/lep/Workspace/guided-diffusion/data/tabula_muris/all.h5ad",
+    )
     parser.add_argument("--loss_ae", type=str, default="mse")
     parser.add_argument("--decoder_activation", type=str, default="ReLU")
-
-    # AE arguments                                             
-    parser.add_argument("--local_rank", type=int, default=0)  
+    parser.add_argument("--resume_checkpoint", action="store_true")
     parser.add_argument("--split_seed", type=int, default=1234)
-    parser.add_argument("--num_genes", type=int, default=18996)
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--strategy", type=str, default="ddp")
     parser.add_argument("--hparams", type=str, default="")
-
-    # training arguments
     parser.add_argument("--max_steps", type=int, default=200000)
     parser.add_argument("--max_minutes", type=int, default=3000)
     parser.add_argument("--checkpoint_freq", type=int, default=50000)
-    parser.add_argument("--batch_size", type=int, default=128)
-    parser.add_argument("--state_dict", type=str, default="/data1/lep/Workspace/guided-diffusion/scimilarity-main/models/annotation_model_v1")  # if pretrain
-    # parser.add_argument("--state_dict", type=str, default=None)   # if not pretrain
-
-    parser.add_argument("--save_dir", type=str, default='../output/ae_checkpoint/muris_AE')
+    parser.add_argument("--batch_size", type=int, default=2048)
+    parser.add_argument("--file_size", type=int, default=100)
+    parser.add_argument("--state_dict", type=str, default=None)
+    parser.add_argument(
+        "--save_dir",
+        type=str,
+        default="../output/ae_checkpoint/muris_AE",
+    )
     parser.add_argument("--sweep_seeds", type=int, default=200)
-    return dict(vars(parser.parse_args()))
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--log_dir", type=str, default=None)
+    parser.add_argument("--use_swanlab", action="store_true", help="Enable swanlab logger")
+    parser.add_argument("--swanlab_project", type=str, default="VAE-Lightning-Project")
+    parser.add_argument("--swanlab_name", type=str, default=None)
+    parser.add_argument("--swanlab_id", type=str, default="")
+    parser.add_argument("--no_progress", action="store_false", dest="progress")
+    parser.add_argument("--enable_schd", action="store_true", help="Enable CosineAnnealingLR scheduler")
+    parser.add_argument("--warmup_steps", type=int, default=0)
+    parser.add_argument("--T_max", type=int, default=0, help="CosineAnnealingLR: max number of steps")
+    parser.add_argument("--eta_min", type=float, default=0.0, help="CosineAnnealingLR: min lr")
+    return vars(parser.parse_args())
+
+
+class LightningVAE(pl.LightningModule):
+    def __init__(
+        self,
+        loss_ae,
+        hidden_dim,
+        decoder_activation,
+        warmup_steps=0,
+        lr=1e-3,
+        enable_schd=False,
+        T_max=1000,
+        eta_min=0.0,
+    ):
+        super().__init__()
+        self.VAE = partial(
+            VAE,
+            loss_ae=loss_ae,
+            hidden_dim=hidden_dim,
+            decoder_activation=decoder_activation,
+        )
+        self.save_hyperparameters(ignore=["vae"])
+        self.lr = lr
+        self.vae = None
+
+    def configure_model(self):
+        if self.vae is None:
+            ds = self.trainer.datamodule
+            self.vae = self.VAE(num_genes=ds.gene_dim)
+
+    def training_step(self, batch, batch_idx):
+        self.configure_model()
+        genes, _ = batch
+        gene_reconstructions = self.vae(genes)
+        loss = self.vae.loss_autoencoder(gene_reconstructions, genes)
+        lr = self.trainer.optimizers[0].param_groups[0]["lr"]
+        self.log("train_loss", loss, on_step=True, on_epoch=True, prog_bar=True)
+        self.log("lr", lr, on_step=True, prog_bar=True, logger=False)
+        return loss
+
+    def configure_optimizers(self):
+        self.configure_model()
+        params = list(self.vae.encoder.parameters()) + list(self.vae.decoder.parameters())
+        optimizer = torch.optim.AdamW(
+            params,
+            lr=self.vae.hparams["autoencoder_lr"],
+            weight_decay=self.vae.hparams["autoencoder_wd"],
+        )
+
+        if getattr(self.hparams, "enable_schd", False):
+            schedulers = []
+            milestones = []
+            if self.hparams.warmup_steps > 0:
+                start_factor = 1.0 / float(self.hparams.warmup_steps)
+                warmup = LinearLR(
+                    optimizer,
+                    start_factor=start_factor,
+                    end_factor=1.0,
+                    total_iters=self.hparams.warmup_steps,
+                )
+                schedulers.append(warmup)
+                milestones.append(self.hparams.warmup_steps)
+
+            if self.hparams.T_max > self.hparams.warmup_steps:
+                schedulers.append(
+                    CosineAnnealingLR(
+                        optimizer,
+                        T_max=self.hparams.T_max - self.hparams.warmup_steps,
+                        eta_min=self.hparams.eta_min,
+                    )
+                )
+
+            if len(schedulers) == 1:
+                sched = schedulers[0]
+            else:
+                sched = SequentialLR(optimizer, schedulers=schedulers, milestones=milestones)
+
+            return {
+                "optimizer": optimizer,
+                "lr_scheduler": {
+                    "scheduler": sched,
+                    "interval": "step",
+                    "frequency": 1,
+                },
+            }
+
+        return optimizer
+
+
+def train_vae_lightning(args):
+
+    seed_everything(args["seed"])
+
+    if args["T_max"] <= 0:
+        args["T_max"] = args["max_steps"]
+
+    data_module = CellDataModule(
+        spec_path=args["data_jsonl"],
+        batch_size=args["batch_size"],
+        file_size=args["file_size"],
+        use_controlnet=False,
+        keep_nz_ratio=1.0,
+        keep_z_ratio=1.0,
+        use_prompts=False,
+        use_smiles=False,
+    )
+
+    model = LightningVAE(
+        loss_ae=args["loss_ae"],
+        hidden_dim=128,
+        decoder_activation=args["decoder_activation"],
+        warmup_steps=args.get("warmup_steps", 0),
+        lr=args.get("lr", 1e-3),
+        enable_schd=args.get("enable_schd", False),
+        T_max=args.get("T_max", 1000),
+        eta_min=args.get("eta_min", 0.0),
+    )
+
+    os.makedirs(args["save_dir"], exist_ok=True)
+
+    callbacks = [
+        ModelCheckpoint(
+            dirpath=args["save_dir"],
+            every_n_train_steps=args["checkpoint_freq"],
+            save_top_k=-1,
+            save_on_train_epoch_end=True,
+            filename="period-{step}",
+        ),
+        ModelCheckpoint(
+            dirpath=args["save_dir"],
+            monitor="train_loss",
+            save_top_k=1,
+            mode="min",
+            filename="best",
+        ),
+        LearningRateMonitor(logging_interval="step"),
+        RichModelSummary(max_depth=5),
+    ]
+    theme = RichProgressBarTheme()
+    theme.metrics_format = ".3e"
+    if args["progress"]:
+        callbacks.append(RichProgressBar(theme=theme))
+
+    log_dir = args["log_dir"]
+    if log_dir is None:
+        log_dir = os.path.join(args["save_dir"], "log")
+        os.makedirs(log_dir, exist_ok=True)
+    loggers = []
+    tb_logger = TensorBoardLogger(save_dir=log_dir, name=args["swanlab_name"])
+    loggers.append(tb_logger)
+    if args.get("use_swanlab", False) and SwanLabLogger is not None:
+        wandb_logger = SwanLabLogger(
+            project=args["swanlab_project"],
+            experiment_name=args["swanlab_name"],
+            save_dir=log_dir,
+            config=args,
+            id=args.get("swanlab_id") if args["resume_checkpoint"] else None,
+            resume="allow" if args["resume_checkpoint"] else None,
+        )
+        loggers.append(wandb_logger)
+    if not args["progress"]:
+        concole_logger = ConsoleLogger(precision=4)
+        loggers.append(concole_logger)
+
+    local_world_size = int(os.environ.get("LOCAL_WORLD_SIZE", 1))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    num_nodes = world_size // max(local_world_size, 1)
+    num_gpus = torch.cuda.device_count()
+
+    if num_gpus > 1:
+        accelerator = "gpu"
+        strategy = FSDPStrategy() if args["strategy"] == "fsdp" else DDPStrategy()
+    elif num_gpus == 1:
+        accelerator = "gpu"
+        strategy = "auto"
+    else:
+        accelerator = "cpu"
+        strategy = "auto"
+
+    trainer = pl.Trainer(
+        max_epochs=-1,
+        max_steps=args["max_steps"],
+        max_time={"minutes": args["max_minutes"]},
+        callbacks=callbacks,
+        default_root_dir=args["save_dir"],
+        enable_checkpointing=True,
+        log_every_n_steps=50,
+        accelerator=accelerator,
+        devices=local_world_size,
+        num_nodes=num_nodes,
+        logger=loggers,
+        strategy=strategy,
+    )
+
+    ckpt_path = None
+    if args["resume_checkpoint"]:
+        ckpt_path = os.path.join(args["save_dir"], "last.ckpt")
+
+    trainer.fit(model, datamodule=data_module, ckpt_path=ckpt_path)
+    return model
 
 
 if __name__ == "__main__":
-    seed_everything(1234)
-    train_vae(parse_arguments())
+    args = parse_arguments()
+    train_vae_lightning(args)
+

--- a/cell_predict.py
+++ b/cell_predict.py
@@ -1,0 +1,167 @@
+import argparse
+import os
+import torch as th
+import pytorch_lightning as pl
+from pytorch_lightning.strategies import DDPStrategy, FSDPStrategy
+from pytorch_lightning import seed_everything
+import numpy as np
+import scanpy as sc
+import pandas as pd
+
+from guided_diffusion.script_util import (
+    model_and_diffusion_defaults,
+    create_model_and_diffusion,
+    create_controlled_model_and_diffusion,
+    args_to_dict,
+    add_dict_to_argparser,
+)
+from guided_diffusion.lightning_module import DiffusionLitModule
+from guided_diffusion.lightning_data import CellDataModule
+from torch.utils.data import DataLoader
+
+th.set_float32_matmul_precision('medium')
+
+class _DummyModule(pl.LightningDataModule):
+    def __init__(self, total, batch_size, gene_dim):
+        self.total = total
+        self.batch_size = batch_size
+        self.gene_dim = gene_dim
+
+    def predict_dataloader(self):
+        return DataLoader(
+            list(range(self.total)),
+            batch_size=self.batch_size,
+            shuffle=False,
+            collate_fn=lambda b: len(b),
+        )
+
+
+def _save_to_h5ad(decoded, save_dir, gene_names=None):
+    """Store decoded samples in an ``h5ad`` file."""
+    decoded = decoded.cpu().numpy()
+    if gene_names is None:
+        gene_names = [f"gene{i}" for i in range(decoded.shape[1])]
+    adata = sc.AnnData(X=decoded, var=pd.DataFrame(index=gene_names))
+    os.makedirs(save_dir, exist_ok=True)
+    adata.write_h5ad(os.path.join(save_dir, "samples.h5ad"))
+    return adata
+
+def main():
+    args = create_argparser().parse_args()
+    seed_everything(args.seed)
+
+    if args.data_jsonl:
+        model, diffusion = create_controlled_model_and_diffusion(
+            **args_to_dict(args, model_and_diffusion_defaults().keys())
+        )
+    else:
+        model, diffusion = create_model_and_diffusion(
+            **args_to_dict(args, model_and_diffusion_defaults().keys())
+        )
+
+    num_samples_per_cond = args.num_samples if args.data_jsonl else 1
+
+    lit_model = DiffusionLitModule(
+        model=model,
+        diffusion=diffusion,
+        schedule_sampler=None,
+        hidden_dim=128,
+        prompt_arg=args.prompts if args.prompts else None,
+        smiles_arg=args.smiles if args.smiles else None,
+        num_samples_per_cond=num_samples_per_cond,
+    )
+
+    ckpt = th.load(args.ckpt_path, map_location="cpu", weights_only=False)
+    if "state_dict" in ckpt:
+        lit_model.load_state_dict(ckpt["state_dict"], strict=False)
+    else:
+        lit_model.load_state_dict(ckpt, strict=False)
+    lit_model.eval()
+
+    if args.data_jsonl:
+        data_module = CellDataModule(
+            spec_path=args.data_jsonl,
+            batch_size=args.batch_size,
+            file_size=args.file_size,
+            use_controlnet=True,
+            keep_nz_ratio=args.keep_nz_ratio,
+            keep_z_ratio=args.keep_z_ratio,
+            use_prompts=(args.prompts == ""),
+            use_smiles=(args.smiles == ""),
+        )
+        data_module.setup()
+        first_file = data_module.dataset.files[0]
+        ad = sc.read_h5ad(first_file, backed="r")
+        gene_names = list(ad.var_names)
+        ad.file.close()
+        gene_dim = data_module.gene_dim
+    else:
+        if args.gene_name:
+            ad = sc.read_h5ad(args.gene_name, backed="r")
+            gene_names = list(ad.var_names)
+            gene_dim = len(gene_names)
+            ad.file.close()
+        else:
+            gene_names = None
+            gene_dim = args.gene_dim
+        data_module = _DummyModule(args.num_samples, args.batch_size, gene_dim)
+
+    num_gpus = th.cuda.device_count()
+    if num_gpus > 1:
+        accelerator = "gpu"
+        devices = num_gpus
+        strategy = FSDPStrategy() if args.strategy == "fsdp" else DDPStrategy()
+    elif num_gpus == 1:
+        accelerator = "gpu"
+        devices = num_gpus
+        strategy = "auto"
+    else:
+        accelerator = "cpu"
+        devices = None
+        strategy = "auto"
+
+    trainer = pl.Trainer(accelerator=accelerator, strategy=strategy, devices=devices)
+
+    outputs = trainer.predict(lit_model, datamodule=data_module)
+    latents_list, samples_list = zip(*outputs)
+
+    samples = th.cat(samples_list, dim=0)
+
+    if gene_names is not None and gene_dim == samples.shape[1]:
+        valid_names = gene_names
+    else:
+        valid_names = None
+
+    _save_to_h5ad(samples, args.save_dir, valid_names)
+
+    if latents_list:
+        latents = th.cat(latents_list, dim=0)
+        os.makedirs(args.save_dir, exist_ok=True)
+        np.savez(os.path.join(args.save_dir, "latents.npz"), cell_gen=latents.numpy())
+
+
+def create_argparser():
+    defaults = dict(
+        num_samples=1000,
+        batch_size=1000,
+        ckpt_path="/path/to/ckpt.ckpt",
+        gene_name="",
+        gene_dim=0,
+        data_jsonl="",
+        save_dir="output/predict",
+        prompts="",
+        smiles="",
+        file_size=1,
+        keep_nz_ratio=1.0,
+        keep_z_ratio=1.0,
+        strategy="ddp",
+        seed=42,
+    )
+    defaults.update(model_and_diffusion_defaults())
+    parser = argparse.ArgumentParser()
+    add_dict_to_argparser(parser, defaults)
+    return parser
+
+
+if __name__ == "__main__":
+    main()

--- a/cell_train.py
+++ b/cell_train.py
@@ -3,8 +3,8 @@ Train a diffusion model on cells using PyTorch Lightning.
 """
 import argparse
 import os
+import torch as th
 
-import pytorch_lightning as pl
 from pytorch_lightning.callbacks import (
     ModelCheckpoint,
     LearningRateMonitor,
@@ -16,7 +16,9 @@ from pytorch_lightning.loggers import (
     TensorBoardLogger,
     WandbLogger,
 )
-from pytorch_lightning.utilities.seed import seed_everything
+import pytorch_lightning as pl
+from pytorch_lightning.strategies import DDPStrategy, FSDPStrategy
+from pytorch_lightning import seed_everything
 
 from guided_diffusion.resample import create_named_schedule_sampler
 from guided_diffusion.script_util import (
@@ -30,10 +32,12 @@ from guided_diffusion.lightning_module import DiffusionLitModule
 from guided_diffusion.lightning_data import CellDataModule
 from guided_diffusion.ema_callback import EMACallback
 
+from console_logger import ConsoleLogger
 
 def main():
-    seed_everything(1234)
+
     args = create_argparser().parse_args()
+    seed_everything(args.seed)
 
     if args.use_controlnet:
         model, diffusion = create_controlled_model_and_diffusion(
@@ -52,9 +56,12 @@ def main():
         weight_decay=args.weight_decay,
         schedule_sampler=schedule_sampler,
         lr_anneal_steps=args.lr_anneal_steps,
+        warmup_steps=args.warmup_steps,
+        lr_scheduler=args.lr_scheduler,
         vae_path=args.vae_path,
-        train_vae=False,
+        model_path=args.model_path,
         hidden_dim=128,
+        resume_checkpoint=args.resume_checkpoint,
     )
 
     data_module = CellDataModule(
@@ -62,7 +69,10 @@ def main():
         batch_size=args.batch_size,
         file_size=args.file_size,
         use_controlnet=args.use_controlnet,
-        keep_ratio=args.keep_ratio,
+        keep_nz_ratio=args.keep_nz_ratio,
+        keep_z_ratio=args.keep_z_ratio,
+        use_prompts=args.use_prompts,
+        use_smiles=args.use_smiles,
     )
 
     period_checkpoint = ModelCheckpoint(
@@ -77,30 +87,74 @@ def main():
         filename="best-{step}"
     )
     lr_monitor = LearningRateMonitor(logging_interval="step")
-    progress_bar = RichProgressBar()
     model_summary = RichModelSummary()
+    progress_bar = RichProgressBar() if not args.no_progress else None
     ema_callback = EMACallback(ema_rate=float(args.ema_rate))
     csv_logger = CSVLogger(args.save_dir, name=args.model_name)
     tb_logger = TensorBoardLogger(save_dir=args.save_dir, name=f"{args.model_name}_tb")
     wandb_logger = WandbLogger(name=args.model_name, save_dir=args.save_dir, project=args.model_name)
+    console_logger = ConsoleLogger() if args.no_progress else None
 
-    trainer = pl.Trainer(
+    num_gpus = th.cuda.device_count()
+    local_rank = os.environ.get("LOCAL_RANK")
+    if num_gpus > 1:
+        accelerator = "gpu"
+        if local_rank is None:
+            devices = num_gpus
+        else:
+            # running under torchrun -> each process handles one GPU
+            devices = 1
+        if args.strategy == "fsdp":
+            strategy = FSDPStrategy()
+        else:
+            strategy = DDPStrategy()
+    else:
+        accelerator = "gpu" if num_gpus == 1 else "cpu"
+        devices = 1 if num_gpus == 1 else None
+        strategy = "auto"
+
+    callbacks = [period_checkpoint, best_checkpoint, lr_monitor, model_summary, ema_callback]
+    if progress_bar is not None:
+        callbacks.insert(3, progress_bar)
+
+    loggers = [csv_logger, tb_logger, wandb_logger]
+    if console_logger is not None:
+        loggers.append(console_logger)
+
+    trainer_kwargs = dict(
         max_steps=args.lr_anneal_steps,
         log_every_n_steps=args.log_interval,
-        logger=[csv_logger, tb_logger, wandb_logger],
-        callbacks=[
-            period_checkpoint,
-            best_checkpoint,
-            lr_monitor,
-            progress_bar,
-            model_summary,
-            ema_callback,
-        ],
-        accelerator="auto",
-        devices=1,
+        logger=loggers,
+        callbacks=callbacks,
+        accelerator=accelerator,
+        strategy=strategy,
         reload_dataloaders_every_n_epochs=1,
+        enable_progress_bar=progress_bar is not None,
+        gradient_clip_val=args.gradient_clip_val,
+        gradient_clip_algorithm=args.gradient_clip_algorithm,
+        accumulate_grad_batches=args.accumulate_grad_batches,
+        precision=args.precision,
     )
-    trainer.fit(lit_model, datamodule=data_module)
+    if devices is not None:
+        trainer_kwargs["devices"] = devices
+
+    trainer = pl.Trainer(**trainer_kwargs)
+
+    ckpt_path = None
+    if args.resume_checkpoint:
+        ckpt_path = os.path.join(args.save_dir, args.model_name, "last.ckpt")
+    else:
+        checkpoint = {}
+        if args.ckpt_path:
+            checkpoint = th.load(args.ckpt_path, map_location="cpu")
+        checkpoint.setdefault("state_dict", {})
+        lit_model.on_load_checkpoint(checkpoint)
+        if checkpoint["state_dict"]:
+            lit_model.load_state_dict(checkpoint["state_dict"], strict=False)
+        if args.ckpt_path:
+            ema_callback.on_load_checkpoint(None, lit_model, checkpoint)
+
+    trainer.fit(lit_model, datamodule=data_module, ckpt_path=ckpt_path)
 
 
 def create_argparser():
@@ -110,24 +164,36 @@ def create_argparser():
         lr=1e-4,
         weight_decay=0.0001,
         lr_anneal_steps=500000,
+        warmup_steps=0,
+        lr_scheduler="lambda",
         batch_size=128,
         file_size=1,
         microbatch=-1,
         ema_rate="0.9999",
         log_interval=100,
         save_interval=200000,
-        resume_checkpoint="",
-        use_fp16=False,
-        fp16_scale_growth=1e-3,
+        ckpt_path="",
+        model_path="",
+        gradient_clip_val=0.0,
+        gradient_clip_algorithm="norm",
+        accumulate_grad_batches=1,
+        precision="32",
         vae_path="output/Autoencoder_checkpoint/muris_AE/model_seed=0_step=0.pt",
         use_controlnet=False,
-        keep_ratio=0.5,
+        keep_nz_ratio=0.5,
+        keep_z_ratio=0.0,
+        use_prompts=True,
+        use_smiles=True,
+        seed=1234,
+        no_progress=False,
+        strategy="ddp",
         model_name="muris_diffusion",
         save_dir="output/diffusion_checkpoint",
     )
     defaults.update(model_and_diffusion_defaults())
     parser = argparse.ArgumentParser()
     add_dict_to_argparser(parser, defaults)
+    parser.add_argument("--resume_checkpoint", action="store_true", help="resume from last checkpoint in save_dir")
     return parser
 
 

--- a/console_logger.py
+++ b/console_logger.py
@@ -1,0 +1,76 @@
+import logging
+
+from pytorch_lightning.loggers import Logger
+from pytorch_lightning.utilities.rank_zero import (
+    rank_zero_experiment,
+    rank_zero_only,
+)
+
+class ConsoleLogger(Logger):
+    """Simple logger that prints metrics to the console using ``logging``.
+
+    Parameters
+    ----------
+    precision : int or None, optional
+        If set, numerical metrics are formatted with this many decimal places.
+        ``None`` disables rounding.
+    fmt : {"e", "f"}, optional
+        Format style for floating point numbers, either scientific (``"e"``)
+        or fixed-point (``"f"``). Default is ``"f"``.
+    """
+
+    def __init__(self, precision=None, fmt="f"):
+        super().__init__()
+        self._step = 0
+        self.precision = precision
+        self.fmt = fmt
+        self.logger = logging.getLogger("ConsoleLogger")
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter(
+                "%(asctime)s - %(levelname)s - %(message)s"
+            )
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+        self.logger.setLevel(logging.INFO)
+
+    @property
+    def name(self):
+        return "console"
+
+    @property
+    def version(self):
+        return "0"
+
+    @property
+    @rank_zero_experiment
+    def experiment(self):
+        return self.logger
+
+    @rank_zero_only
+    def log_hyperparams(self, params):
+        self.logger.info("Hyperparameters:")
+        for k, v in params.items():
+            self.logger.info("  %s: %s", k, v)
+
+    @rank_zero_only
+    def log_metrics(self, metrics, step=None):
+        if step is not None:
+            self._step = step
+        formatted = []
+        for k, v in metrics.items():
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                if isinstance(v, float) and self.precision is not None:
+                    value = format(v, f".{self.precision}{self.fmt}")
+                else:
+                    value = str(v)
+            else:
+                value = str(v)
+            formatted.append(f"{k}={value}")
+        metric_str = ", ".join(formatted)
+        self.logger.info("step %s: %s", self._step, metric_str)
+
+    @rank_zero_only
+    def finalize(self, status):
+        self.logger.info("Run finished with status: %s", status)
+

--- a/guided_diffusion/lightning_data.py
+++ b/guided_diffusion/lightning_data.py
@@ -2,6 +2,7 @@ import pytorch_lightning as pl
 from torch.utils.data import DataLoader
 import json
 import os
+import yaml
 from torch.utils.data.dataloader import default_collate
 
 from .cell_datasets_loader import StreamingCellDataset
@@ -22,25 +23,47 @@ class CellDataModule(pl.LightningDataModule):
         Path to a JSONL file describing datasets or a directory containing
         multiple ``.jsonl`` files. Each line in a JSONL file should be a JSON
         object with ``data_dir`` pointing to the dataset location, ``data_type``
-        of either ``h5ad`` or ``mtx``, ``prompt_template`` for formatting
-        prompts (or ``None`` to skip PubMedBERT), and ``smiles`` containing the
-        column name with SMILES strings (or ``None`` to skip ChemBERT).
+        of either ``h5ad`` or ``mtx``, ``prompt_template_file`` pointing to a
+        YAML file containing a list of prompt templates (or ``None`` to skip
+        PubMedBERT), and ``smiles`` containing the column name with SMILES
+        strings (or ``None`` to skip ChemBERT).
     batch_size : int
         Number of samples per batch.
     use_controlnet : bool, optional
         Whether to prepare ControlNet inputs.
-    keep_ratio : float, optional
-        Ratio of expression values kept for ControlNet inputs.
+    keep_nz_ratio : float, optional
+        Ratio of non-zero expression values kept for ControlNet inputs.
+    keep_z_ratio : float, optional
+        Ratio of zero expression values kept for ControlNet inputs.
+    use_prompts : bool, optional
+        Whether to return prompt strings with each sample.
+    use_smiles : bool, optional
+        Whether to return SMILES strings with each sample.
     """
 
-    def __init__(self, spec_path, batch_size, file_size=1, num_workers=12, use_controlnet=False, keep_ratio=0.5, path_replace=None):
+    def __init__(
+        self,
+        spec_path,
+        batch_size,
+        file_size=1,
+        num_workers=12,
+        use_controlnet=False,
+        keep_nz_ratio=0.5,
+        keep_z_ratio=0.0,
+        use_prompts=True,
+        use_smiles=True,
+        path_replace=None,
+    ):
         super().__init__()
         self.spec_path = spec_path
         self.batch_size = batch_size
         self.file_size = file_size
         self.num_workers = num_workers
         self.use_controlnet = use_controlnet
-        self.keep_ratio = keep_ratio
+        self.keep_nz_ratio = keep_nz_ratio
+        self.keep_z_ratio = keep_z_ratio
+        self.use_prompts = use_prompts
+        self.use_smiles = use_smiles
         if path_replace is None:
             self.path_replace = ["", ""]
         else:
@@ -49,19 +72,26 @@ class CellDataModule(pl.LightningDataModule):
     def setup(self, stage=None):
         specs = []
         paths = []
-        if os.path.isdir(self.spec_path):
-            for fname in sorted(os.listdir(self.spec_path)):
-                if fname.endswith(".jsonl"):
-                    paths.append(os.path.join(self.spec_path, fname))
+        if isinstance(self.spec_path, str):
+            spec_paths = [sp.strip() for sp in self.spec_path.split(',') if sp.strip()]
         else:
-            paths.append(self.spec_path)
+            spec_paths = list(self.spec_path)
 
-        for p in paths:
+        for path_idx, sp in enumerate(spec_paths):
+            if os.path.isdir(sp):
+                for fname in sorted(os.listdir(sp)):
+                    if fname.endswith(".jsonl"):
+                        paths.append((os.path.join(sp, fname), path_idx))
+            else:
+                paths.append((sp, path_idx))
+
+        for p, ds_idx in paths:
             with open(p, "r") as f:
                 for line in f:
                     line = line.strip()
                     if line:
-                        specs.append(json.loads(line))
+                        spec = json.loads(line)
+                        specs.append((spec, ds_idx))
 
         files = []
         lengths = []
@@ -69,15 +99,36 @@ class CellDataModule(pl.LightningDataModule):
         smiles_cols = []
         self.gene_dim = None
 
-        for spec in specs:
+        ds_ids = []
+        for spec, ds_idx in specs:
             data_path = spec["data_path"].replace(*self.path_replace)
             if not os.path.exists(data_path):
                 continue
             files.append(data_path)
             length = spec["n_obs"]
             lengths.append(length)
-            prompt_templates.append(spec.get("prompt_template"))
-            smiles_cols.append(spec.get("smiles"))
+            ds_ids.append(ds_idx)
+            if self.use_prompts:
+                tmpl_file = spec.get("prompt_template_file")
+                if tmpl_file is not None:
+                    tmpl_file = tmpl_file.replace(*self.path_replace)
+                    with open(tmpl_file, "r") as f:
+                        templates = yaml.safe_load(f)
+                    if not isinstance(templates, list):
+                        raise ValueError(
+                            f"YAML template file {tmpl_file} must contain a list"
+                        )
+                else:
+                    templates = spec.get("prompt_template")
+            else:
+                templates = None
+            prompt_templates.append(templates)
+
+            if self.use_smiles:
+                smiles_cols.append(spec.get("smiles"))
+            else:
+                smiles_cols.append(None)
+
             if self.gene_dim is None:
                 self.gene_dim = spec.get("gene_dim")
 
@@ -85,15 +136,21 @@ class CellDataModule(pl.LightningDataModule):
         self.lengths_all = lengths
         self.prompts_all = prompt_templates
         self.smiles_all = smiles_cols
+        self.ds_ids_all = ds_ids
+        from collections import Counter
+        self.ds_counts = {k: v for k, v in Counter(ds_ids).items()}
 
         self.dataset = StreamingCellDataset(
             self.files_all,
             self.lengths_all,
             prompt_templates=self.prompts_all,
             smiles_cols=self.smiles_all,
+            ds_ids=self.ds_ids_all,
+            ds_counts=self.ds_counts,
             file_size=self.file_size,
             use_controlnet=self.use_controlnet,
-            keep_ratio=self.keep_ratio,
+            keep_nz_ratio=self.keep_nz_ratio,
+            keep_z_ratio=self.keep_z_ratio,
         )
 
     def train_dataloader(self):
@@ -107,9 +164,21 @@ class CellDataModule(pl.LightningDataModule):
             collate_fn=self._collate_with_optional,
         )
 
+    def predict_dataloader(self):
+        """Return DataLoader for prediction."""
+        return DataLoader(
+            self.dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            drop_last=False,
+            prefetch_factor=2,
+            collate_fn=self._collate_with_optional,
+        )
+
     @staticmethod
     def _collate_with_optional(batch):
-        arrays, conds = zip(*batch)
+        arrays, conds, ds_ids = zip(*batch)
         arrays = default_collate(arrays)
         cond_batch = {}
         keys = conds[0].keys()
@@ -119,4 +188,5 @@ class CellDataModule(pl.LightningDataModule):
                 cond_batch[key] = list(vals)
             else:
                 cond_batch[key] = default_collate(vals)
-        return arrays, cond_batch
+        ds_ids = default_collate(ds_ids)
+        return arrays, cond_batch, ds_ids

--- a/guided_diffusion/lightning_module.py
+++ b/guided_diffusion/lightning_module.py
@@ -3,7 +3,14 @@ os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
 import pytorch_lightning as pl
 import torch as th
+import math
 from torch.optim import AdamW
+from torch.optim.lr_scheduler import (
+    LambdaLR,
+    SequentialLR,
+    LinearLR,
+    CosineAnnealingLR,
+)
 from transformers import AutoTokenizer, AutoModel
 
 from .cell_datasets_loader import load_VAE, read_h5ad_backed
@@ -25,23 +32,30 @@ class DiffusionLitModule(pl.LightningModule):
         weight_decay=0.0,
         schedule_sampler=None,
         lr_anneal_steps=0,
+        warmup_steps=0,
+        lr_scheduler="lambda",
         vae_path=None,
-        train_vae=False,
+        model_path=None,
         hidden_dim=128,
+        prompt_arg=None,
+        smiles_arg=None,
+        num_samples_per_cond=1,
+        resume_checkpoint=False,
     ):
         super().__init__()
+        lr = float(lr)
+        schedule_sampler = schedule_sampler or UniformSampler(diffusion)
+        self.save_hyperparameters(
+            ignore=["model", "diffusion"]
+        )
         self.model = model
         self.diffusion = diffusion
-        # ensure learning rate is a float. some callers may accidentally pass a
-        # schedule sampler here which would break the optimizer
-        self.lr = float(lr)
-        self.weight_decay = weight_decay
-        self.schedule_sampler = schedule_sampler or UniformSampler(diffusion)
-        self.lr_anneal_steps = lr_anneal_steps
-        self.vae_path = vae_path
-        self.train_vae = train_vae
-        self.hidden_dim = hidden_dim
         self.autoencoder = None
+        self._model_loaded = False
+        try:
+            self.input_dim = model.layers[0].fc.in_features
+        except AttributeError:
+            self.input_dim = model.unet.layers[0].fc.in_features
 
         # Preload tokenizers and encoders for conditional embeddings
         self.pubmed_tokenizer = AutoTokenizer.from_pretrained(PUBMED_MODEL_NAME)
@@ -55,6 +69,11 @@ class DiffusionLitModule(pl.LightningModule):
         for p in self.chem_token_encoder.parameters():
             p.requires_grad_(False)
         self.embed_dim = self.pubmed_encoder.config.hidden_size
+
+        self.use_controlnet = hasattr(self.model, "control_net")
+        if self.use_controlnet:
+            for p in self.model.unet.parameters():
+                p.requires_grad_(False)
 
         # projector for combined PubMed and Chem embeddings
         self.cond_mapper = th.nn.Sequential(
@@ -78,30 +97,106 @@ class DiffusionLitModule(pl.LightningModule):
             self.cond_mapper[4].bias.zero_()
 
     def configure_model(self, stage=None):
-        if not self.train_vae and self.autoencoder is None:
+        if self.autoencoder is None:
             dm = self.trainer.datamodule
             num_gene = getattr(dm, "gene_dim", None)
             if num_gene is None:
                 ds = dm.dataset
                 path = ds.files[0]
                 num_gene = read_h5ad_backed(path).shape[1]
-            self.autoencoder = load_VAE(self.vae_path, num_gene, self.hidden_dim)
+            self.autoencoder = load_VAE(self.hparams.vae_path, num_gene, self.hparams.hidden_dim)
             self.autoencoder.eval()
             for p in self.autoencoder.parameters():
                 p.requires_grad_(False)
+
+        if self.use_controlnet and self.hparams.model_path and not self._model_loaded:
+            ckpt = th.load(self.hparams.model_path, map_location="cpu")
+            sd = ckpt.get("state_dict", ckpt)
+            src_prefix = "model.unet." if any(k.startswith("model.unet") for k in sd) else "model."
+            tgt_prefix = "model.unet."
+            unet_sd = {k[len(src_prefix):]: v for k, v in sd.items() if k.startswith(src_prefix)}
+            self.model.unet.load_state_dict(unet_sd, strict=False)
+            self._model_loaded = True
+
+    def on_load_checkpoint(self, checkpoint):
+        """Remap state dict keys when ControlNet settings differ."""
+        state_dict = checkpoint.get("state_dict")
+        if state_dict is None:
+            return
+
+        ckpt_has_control = any(k.startswith("model.control_net") for k in state_dict)
+        ckpt_has_unet_prefix = any(k.startswith("model.unet") for k in state_dict)
+        current_has_control = hasattr(self.model, "control_net")
+
+        if getattr(self.hparams, "resume_checkpoint", False) and ckpt_has_control != current_has_control:
+            raise ValueError(
+                "ControlNet setting mismatch between checkpoint and current model when resuming"
+            )
+
+        src_prefix = "model.unet." if ckpt_has_unet_prefix else "model."
+        tgt_prefix = "model.unet." if current_has_control else "model."
+
+        new_state = {}
+        for k, v in state_dict.items():
+            if k.startswith("model.control_net") and not current_has_control:
+                continue
+            if k.startswith(src_prefix):
+                new_key = tgt_prefix + k[len(src_prefix):]
+            else:
+                new_key = k
+            new_state[new_key] = v
+
+        # update in place so Lightning loads the remapped dict
+        state_dict.clear()
+        state_dict.update(new_state)
+
+        # override autoencoder weights when a path is given
+        if self.hparams.vae_path:
+            vae_ckpt = th.load(self.hparams.vae_path, map_location="cpu")
+            vae_sd = vae_ckpt.get("state_dict", vae_ckpt)
+            for k, v in vae_sd.items():
+                state_dict[f"autoencoder.{k}"] = v
+
+        # override model weights when a path is specified
+        if self.hparams.model_path and current_has_control:
+            m_ckpt = th.load(self.hparams.model_path, map_location="cpu")
+            m_sd = m_ckpt.get("state_dict", m_ckpt)
+            src_pre = "model.unet." if any(k.startswith("model.unet") for k in m_sd) else "model."
+            tgt_pre = "model.unet." if current_has_control else "model."
+            for k, v in m_sd.items():
+                if k.startswith("model.control_net") and not current_has_control:
+                    continue
+                if k.startswith(src_pre):
+                    new_k = tgt_pre + k[len(src_pre):]
+                elif k.startswith("diffusion"):
+                    new_k = k
+                else:
+                    continue
+                state_dict[new_k] = v
+
+        # drop optimizer state if parameter counts do not match
+        opt_states = checkpoint.get("optimizer_states")
+        if opt_states:
+            try:
+                ckpt_params = sum(len(g["params"]) for g in opt_states[0]["param_groups"])
+                curr_params = sum(1 for _ in self.model.parameters())
+            except Exception:
+                ckpt_params = curr_params = -1
+            if ckpt_params != curr_params:
+                checkpoint.pop("optimizer_states", None)
+                checkpoint.pop("lr_schedulers", None)
 
     def on_fit_start(self):
         self.configure_model()
 
     def training_step(self, batch, batch_idx):
-        x, cond = batch
-        if not self.train_vae:
-            with th.no_grad():
-                x = self.autoencoder(x, return_latent=True)
-                if "control" in cond and cond["control"] is not None:
-                    ctrl = cond["control"]
-                    ctrl = self.autoencoder(ctrl, return_latent=True)
-                    cond["control"] = ctrl
+        x, cond, _ = batch
+        with th.no_grad():
+            x = self.autoencoder(x, return_latent=True)
+            if "control" in cond and cond["control"] is not None:
+                ctrl = cond["control"]
+                ctrl = self.autoencoder(ctrl, return_latent=True)
+                cond["control"] = ctrl
         prompts = cond.pop("prompt", None)
         smiles = cond.pop("smiles", None)
         cond_emb = None
@@ -159,11 +254,11 @@ class DiffusionLitModule(pl.LightningModule):
         if cond_emb is not None:
             cond["cond_emb"] = cond_emb
 
-        t, weights = self.schedule_sampler.sample(x.shape[0], x.device)
+        t, weights = self.hparams.schedule_sampler.sample(x.shape[0], x.device)
         losses = self.diffusion.training_losses(self.model, x, t, model_kwargs=cond)
 
-        if isinstance(self.schedule_sampler, LossAwareSampler):
-            self.schedule_sampler.update_with_local_losses(t, losses["loss"].detach())
+        if isinstance(self.hparams.schedule_sampler, LossAwareSampler):
+            self.hparams.schedule_sampler.update_with_local_losses(t, losses["loss"].detach())
 
         # map timesteps to quartile ids without leaving the device
         quartiles = (t * 4 // self.diffusion.num_timesteps).long()
@@ -171,7 +266,14 @@ class DiffusionLitModule(pl.LightningModule):
         for key, val in losses.items():
             weighted = val * weights
             mean_val = weighted.mean()
-            self.log(key, mean_val, prog_bar=key in ["loss", "mse"], on_step=True, on_epoch=False)
+            self.log(
+                key,
+                mean_val,
+                prog_bar=key in ["loss", "mse"],
+                on_step=True,
+                on_epoch=False,
+                sync_dist=True,
+            )
 
             # Log quartile statistics to match the original logger behaviour
             for q in range(4):
@@ -182,6 +284,7 @@ class DiffusionLitModule(pl.LightningModule):
                         weighted[mask].mean().item(),
                         on_step=True,
                         on_epoch=False,
+                        sync_dist=True,
                     )
 
         return (losses["loss"] * weights).mean()
@@ -193,27 +296,196 @@ class DiffusionLitModule(pl.LightningModule):
             param_norm += p.data.norm(2).item() ** 2
             if p.grad is not None:
                 grad_norm += p.grad.norm(2).item() ** 2
-        self.log("grad_norm", grad_norm ** 0.5, on_step=True, on_epoch=False)
-        self.log("param_norm", param_norm ** 0.5, on_step=True, on_epoch=False)
+        self.log(
+            "grad_norm",
+            grad_norm ** 0.5,
+            on_step=True,
+            on_epoch=False,
+            sync_dist=True,
+        )
+        self.log(
+            "param_norm",
+            param_norm ** 0.5,
+            on_step=True,
+            on_epoch=False,
+            sync_dist=True,
+        )
 
     def on_train_batch_end(self, outputs, batch, batch_idx):
         batch_size = batch[0].size(0)
         samples = (self.global_step + 1) * batch_size
-        self.log("samples", float(samples), on_step=True, on_epoch=False)
-        self.log("step", float(self.global_step + 1), on_step=True, on_epoch=False)
+        self.log("samples", float(samples), on_step=True, on_epoch=False, sync_dist=True)
+        self.log("step", float(self.global_step + 1), on_step=True, on_epoch=False, sync_dist=True)
 
 
     def configure_optimizers(self):
-        opt = AdamW(self.model.parameters(), lr=self.lr, weight_decay=self.weight_decay)
-        if self.lr_anneal_steps > 0:
-            scheduler = th.optim.lr_scheduler.LambdaLR(
-                opt,
-                lambda step: 1 - min(step, self.lr_anneal_steps) / float(self.lr_anneal_steps),
-            )
-            return [opt], [
-                {
-                    "scheduler": scheduler,
-                    "interval": "step",
-                }
-            ]
+        params = []
+        if self.use_controlnet:
+            params.extend(self.model.control_net.parameters())
+        else:
+            params.extend(self.model.parameters())
+
+        # always train the conditional mapper
+        params.extend(self.cond_mapper.parameters())
+
+
+        opt = AdamW(params, lr=self.hparams.lr, weight_decay=self.hparams.weight_decay)
+
+        if self.hparams.lr_anneal_steps > 0 or self.hparams.warmup_steps > 0:
+            schedulers = []
+            milestones = []
+
+            if self.hparams.warmup_steps > 0:
+                start_factor = 1.0 / float(self.hparams.warmup_steps)
+                warmup = LinearLR(
+                    opt,
+                    start_factor=start_factor,
+                    end_factor=1.0,
+                    total_iters=self.hparams.warmup_steps,
+                )
+                schedulers.append(warmup)
+                milestones.append(self.hparams.warmup_steps)
+
+            if self.hparams.lr_anneal_steps > self.hparams.warmup_steps:
+                decay_steps = self.hparams.lr_anneal_steps - self.hparams.warmup_steps
+                if self.hparams.lr_scheduler.lower() == "cosine":
+                    scheduler = CosineAnnealingLR(opt, T_max=decay_steps)
+                else:
+                    def lr_lambda(step: int):
+                        progress = min(float(step) / float(decay_steps), 1.0)
+                        return 1.0 - progress
+
+                    scheduler = LambdaLR(opt, lr_lambda)
+                schedulers.append(scheduler)
+
+            if schedulers:
+                if len(schedulers) == 1:
+                    sched = schedulers[0]
+                else:
+                    sched = SequentialLR(opt, schedulers=schedulers, milestones=milestones)
+                return [opt], [{"scheduler": sched, "interval": "step"}]
+
         return opt
+
+    def on_predict_start(self):
+        self.configure_model()
+
+    def predict_step(self, batch, batch_idx, dataloader_idx=0):
+        """Generate samples for the given conditioning batch."""
+        if isinstance(batch, tuple):
+            if len(batch) == 3:
+                arr, cond, _ = batch
+            else:
+                arr, cond = batch
+            if hasattr(arr, "shape"):
+                batch_size = arr.shape[0]
+            else:
+                batch_size = len(arr)
+        elif isinstance(batch, int):
+            cond = {}
+            batch_size = batch
+        else:
+            cond = batch if batch else {}
+            if cond:
+                val = next(iter(cond.values()))
+                if isinstance(val, list):
+                    batch_size = len(val)
+                else:
+                    batch_size = val.shape[0]
+            else:
+                dm = getattr(self.trainer, "datamodule", None)
+                batch_size = getattr(dm, "batch_size", 1)
+
+        prompt_arg = self.hparams.prompt_arg
+        smiles_arg = self.hparams.smiles_arg
+
+        if prompt_arg is not None:
+            cond["prompt"] = [prompt_arg] * batch_size
+        if smiles_arg is not None:
+            cond["smiles"] = [smiles_arg] * batch_size
+
+        if "control" in cond and cond["control"] is not None:
+            with th.no_grad():
+                ctrl = cond["control"].to(self.device)
+                cond["control"] = self.autoencoder(ctrl, return_latent=True)
+
+        prompts = cond.pop("prompt", None)
+        smiles = cond.pop("smiles", None)
+        cond_emb = None
+        emb_pub = None
+        all_prompt_none = prompts is None or all(p is None for p in prompts)
+        all_smiles_none = smiles is None or all(s is None for s in smiles)
+        if prompts is not None:
+            valid_idx = [i for i, p in enumerate(prompts) if p is not None]
+            if valid_idx:
+                with th.no_grad():
+                    tok = self.pubmed_tokenizer(
+                        [prompts[i] for i in valid_idx],
+                        padding=True,
+                        truncation=True,
+                        return_tensors="pt",
+                    )
+                    tok = {k: v.to(self.device) for k, v in tok.items()}
+                    emb = self.pubmed_encoder(**tok).last_hidden_state[:, 0]
+                emb_pub = th.zeros(len(prompts), emb.shape[1], device=self.device)
+                emb_pub[valid_idx] = emb
+            else:
+                emb_pub = th.zeros(batch_size, self.embed_dim, device=self.device)
+        else:
+            emb_pub = th.zeros(batch_size, self.embed_dim, device=self.device)
+
+        emb_chem = None
+        if smiles is not None:
+            valid_idx = [i for i, s in enumerate(smiles) if s is not None]
+            if valid_idx:
+                with th.no_grad():
+                    tok = self.chem_tokenizer(
+                        [smiles[i] for i in valid_idx],
+                        padding=True,
+                        truncation=True,
+                        return_tensors="pt",
+                    )
+                    tok = {k: v.to(self.device) for k, v in tok.items()}
+                    emb = self.chem_token_encoder(**tok).last_hidden_state[:, 0]
+                emb_chem = th.zeros(len(smiles), emb.shape[1], device=self.device)
+                emb_chem[valid_idx] = emb
+            else:
+                emb_chem = th.zeros(batch_size, self.embed_dim, device=self.device)
+        else:
+            emb_chem = th.zeros(batch_size, self.embed_dim, device=self.device)
+
+        if not (all_prompt_none and all_smiles_none):
+            if emb_pub is not None and emb_chem is not None:
+                cond_emb = self.cond_mapper(th.cat([emb_pub, emb_chem], dim=1))
+            elif emb_pub is not None and not all_prompt_none:
+                cond_emb = emb_pub
+            elif emb_chem is not None and not all_smiles_none:
+                cond_emb = emb_chem
+
+        if cond_emb is not None:
+            cond["cond_emb"] = cond_emb
+
+        repeat = self.hparams.num_samples_per_cond
+        if repeat > 1:
+            for k, v in list(cond.items()):
+                if th.is_tensor(v):
+                    cond[k] = v.repeat_interleave(repeat, dim=0)
+                else:
+                    cond[k] = [vv for vv in v for _ in range(repeat)]
+            batch_size *= repeat
+
+        sample_fn = self.diffusion.p_sample_loop
+        latents, _ = sample_fn(
+            self.model,
+            (batch_size, self.input_dim),
+            clip_denoised=True,
+            model_kwargs=cond,
+            device=self.device,
+            progress=False,
+            start_time=self.diffusion.betas.shape[0],
+        )
+
+        with th.no_grad():
+            decoded = self.autoencoder(latents, return_decoded=True)
+
+        return latents.detach().cpu(), decoded.detach().cpu()


### PR DESCRIPTION
## Summary
- assign dataset IDs based on the index of each `data_jsonl` path
- track file counts per path and pass them to `StreamingCellDataset`
- sample files with probability inversely proportional to path size so smaller datasets are upsampled

## Testing
- `python -m py_compile cell_train.py cell_predict.py guided_diffusion/cell_datasets_loader.py guided_diffusion/lightning_data.py console_logger.py guided_diffusion/lightning_module.py guided_diffusion/ema_callback.py VAE/VAE_train.py`

------
https://chatgpt.com/codex/tasks/task_e_68639fcbea70832aab5786ac9a13b2c7